### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,6 +8,10 @@ on:
       - 'v*' # Trigger on version tags like v1.0, v1.2.3
   workflow_dispatch: # Allows manual triggering from the Actions tab
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-release:
     name: Build and Release Executable


### PR DESCRIPTION
Potential fix for [https://github.com/zateckar/ScoopUI/security/code-scanning/1](https://github.com/zateckar/ScoopUI/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow involves checking out code, creating releases, and uploading artifacts, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `packages: write` for creating releases and uploading assets.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`build-and-release`) to limit permissions to that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
